### PR TITLE
:pencil: :ambulance: :elephant: type(activity): str → Object

### DIFF
--- a/src/components/TakeSurvey.vue
+++ b/src/components/TakeSurvey.vue
@@ -5,6 +5,7 @@
       <Survey
         :srcUrl="srcUrl"
         :progress="progress"
+        ref="surveyComponent"
         selected_language="en"
         :responses="responses"
         v-on:updateProgress="updateProgress"
@@ -121,7 +122,7 @@ export default {
       api.sendActivityData({
         data: {
           applet: this.applet,
-          activity: this.srcUrl,
+          activity: this.$refs.surveyComponent.activity,
           responses: this.responses,
         },
         apiHost: this.apiHost,


### PR DESCRIPTION
Resolves
  > and also, saving responses is broken
  — https://matter-lab.slack.com/archives/DE491QLUR/p1554844879092400

  > Ah, we're passing an activity url instead of object on save, and I haven't written code to handle that yet. First thing tomorrow!
  — https://matter-lab.slack.com/archives/DE491QLUR/p1554930875011200