### PR TITLE
fix: hide invite link actions if user signed in and link deleted (web-prod branch)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -115,7 +115,8 @@
     "loading": "Loading invite link",
     "reviewers": "Users who can see your data for this applet:",
     "managers": "Users who can change this applet's settings, including who can access your data:",
-    "coordinators": "Users who can change this applet's settings, but who cannot change who can see your data:"
+    "coordinators": "Users who can change this applet's settings, but who cannot change who can see your data:",
+    "notFound": "The invite link is either invalid or no long active."
   },
   "InvitationButtons": {
     "acceptInvitation": "Accept Invitation",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -115,7 +115,8 @@
     "loading": "Chargement de l'invitation",
     "reviewers": "Utilisateurs qui peuvent voir vos données pour cette applet:",
     "managers": "Utilisateurs qui peuvent modifier les paramètres de cette applet, y compris ceux qui peuvent accéder à vos données:",
-    "coordinators": "Utilisateurs qui peuvent modifier les paramètres de cette applet, mais qui ne peuvent pas changer qui peut voir vos données :"
+    "coordinators": "Utilisateurs qui peuvent modifier les paramètres de cette applet, mais qui ne peuvent pas changer qui peut voir vos données :",
+    "notFound": "L'invitation est invalide ou plus active."
   },
   "InvitationButtons": {
     "acceptInvitation": "Accepter l'invitation",

--- a/src/components/Invitation/Join.js
+++ b/src/components/Invitation/Join.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useLocation, useHistory } from 'react-router-dom';
 
+import {useTranslation} from "react-i18next";
+
 import { Statuses } from '../../constants';
 import { InviteLink } from './InviteLink';
 import { JoinInfo } from './JoinInfo';
@@ -11,6 +13,8 @@ import { loggedInSelector } from '../../state/user/user.selectors';
 import { acceptInviteLink, getInviteLinkInfo } from '../../state/app/app.actions';
 
 export const Join = () => {
+  const { t } = useTranslation();
+
   const history = useHistory();
 
   const { inviteLinkId } = useParams();
@@ -81,6 +85,8 @@ export const Join = () => {
       {renderAcceptDeclineInvite()}
 
       {renderSignIn()}
+
+      {renderNotFound()}
     </div>
   );
 
@@ -93,7 +99,7 @@ export const Join = () => {
   }
 
   function renderAcceptDeclineInvite() {
-    if (!isLoggedIn && status !== Statuses.LOADING) {
+    if (!inviteLink  || !isLoggedIn && status !== Statuses.LOADING) {
       return undefined;
     }
 
@@ -108,5 +114,15 @@ export const Join = () => {
     }
 
     return <SignIn></SignIn>;
+  }
+
+  function renderNotFound() {
+    if (!inviteLink) {
+      return <div className="heading">
+        <p>{t('InviteLink.notFound')}</p>
+      </div>
+    }
+
+    return undefined;
   }
 };


### PR DESCRIPTION
### Reproduction

Steps to reproduce:

1. Create an invite link (admin)
2. Sign in (web)
3. Open invite link (web)
4. Delete invite link (admin)
5. Refresh page (web)

### Actual Behavior

I a signed in user tries to access a delete invite link, the "Accept / Decline Invitation" buttons are displayed even if the invitation is not available anymore.

### Expected Behavior

The "Accept / Decline Invitation" buttons for an invite link should be displayed only if the invite link does exist.

### Credits

This pull request is part of the "Citizen Science Logger" project and, provided by the [ETH Library Lab](https://www.librarylab.ethz.ch/).