### PR TITLE
feat: do not set redirect url for public links (web branch)

### DIFF
--- a/src/components/Invitation/Join.js
+++ b/src/components/Invitation/Join.js
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams, useLocation, useHistory } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 
 import {useTranslation} from "react-i18next";
 
 import { Statuses } from '../../constants';
 import { InviteLink } from './InviteLink';
 import { JoinInfo } from './JoinInfo';
-import { setRedirectUrl } from '../../state/app/app.reducer';
 import { SignIn } from '../Signin/SignIn';
 import { loggedInSelector } from '../../state/user/user.selectors';
 import { acceptInviteLink, getInviteLinkInfo } from '../../state/app/app.actions';
@@ -26,13 +25,6 @@ export const Join = () => {
   const isLoggedIn = useSelector(loggedInSelector);
 
   const dispatch = useDispatch();
-  const location = useLocation();
-
-  useEffect(() => {
-    dispatch(setRedirectUrl(location.pathname));
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
### Actual Behavior

When "nominative / standard applets" invitations are handled by this web app, the "redirect url" (= the link the accept the invitation) is saved in the global store. This store is also persisted in the storage of the browser.

Upon login, this global state is checked and, if existing, the user is redirected to the save "redirect url".

It means that if a user log in, open a "nominative applet" invitation, log out and log in again, he/she will be redirected automatically to this "nominative / standard "applet" invitation.

In addition, it is also worth to notice that if a user accept a "nominative standard applet", this redirect stays in memory and the exact same behavior will happen, except that the user will gets a msg "you  already joined this applet".

As this is the core behavior of the web app, we applied the same logic for the "public applet invitation".

### Expected Behavior

In case of "public applet invitation", this behavior is sub-optimal, as the public invitation mask cannot detect upon presentation if a user has joined or not the applet (= expected defined behavior and feature) therefore cannot display a msg "you  already joined this applet" upfront.

To solve this little quirks and to make the navigation more natural, this PR remove the store's saving of the "redirect url" in case of "public invitation link".

### Demo

[Screenrecording](https://www.dropbox.com/s/0uzn1mgxljqqu06/redirect.mov?dl=0) of the current behavior. After logout, user is redirected to invitation mask again. This won't happen anymore for "public link" once this PR has been merged.

### Credits

This pull request is part of the "Citizen Science Logger" project and, provided by the [ETH Library Lab](https://www.librarylab.ethz.ch/).