### PR TITLE
feat: redirect to join page after sign in/up without state mgmt (web branch)

### DIFF
--- a/src/components/Invitation/Join.js
+++ b/src/components/Invitation/Join.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useLocation, useHistory } from 'react-router-dom';
 
 import {useTranslation} from "react-i18next";
 
@@ -25,6 +25,7 @@ export const Join = () => {
   const isLoggedIn = useSelector(loggedInSelector);
 
   const dispatch = useDispatch();
+  const location = useLocation();
 
   useEffect(() => {
     (async () => {
@@ -105,7 +106,7 @@ export const Join = () => {
       return undefined;
     }
 
-    return <SignIn></SignIn>;
+    return <SignIn redirectUrl={location.pathname}></SignIn>;
   }
 
   function renderNotFound() {

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { push } from 'connected-react-router'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -21,12 +21,16 @@ export default function Login() {
   const dispatch = useDispatch()
   const { redirectUrl } = useSelector(state => state.app);
   let { loading, info, error } = useSelector(state => state.user);
+  const location = useLocation();
 
   useEffect(() => {
     if (!loading && info) {
       setIsStarted(true);
-      if (redirectUrl) dispatch(push(redirectUrl));
-      else {
+      if (redirectUrl) {
+        dispatch(push(redirectUrl));
+      } else if (location.state) {
+        dispatch(push(location.state));
+      } else {
         dispatch(push('/dashboard'));
         dispatch(setRedirectUrl(null));
       }

--- a/src/components/Signin/SignIn.js
+++ b/src/components/Signin/SignIn.js
@@ -6,17 +6,17 @@ import { useTranslation } from 'react-i18next';
 
 import { useHistory } from 'react-router-dom';
 
-export const SignIn = () => {
+export const SignIn = ({redirectUrl}) => {
   const { t } = useTranslation();
 
   const history = useHistory();
 
   const handleLogin = () => {
-    history.push('/login');
+    history.push('/login', redirectUrl);
   };
 
   const handleSignup = () => {
-    history.push('/signup');
+    history.push('/signup', redirectUrl);
   };
 
   return (

--- a/src/components/Signup/index.js
+++ b/src/components/Signup/index.js
@@ -30,8 +30,11 @@ export default () => {
   useEffect(() => {
     if (!loading && info) {
       setIsStarted(true);
-      if (redirectUrl) dispatch(push(redirectUrl));
-      else {
+      if (redirectUrl) {
+        dispatch(push(redirectUrl));
+      } else if (location.state) {
+        dispatch(push(location.state));
+     } else {
         dispatch(push('/profile'));
         dispatch(setRedirectUrl(null));
       }


### PR DESCRIPTION
### Actual Behavior

See https://github.com/ChildMindInstitute/mindlogger-backend/issues/1074#issuecomment-890870822

### Expected Behavior

Redirect to `join` page after sign in / up without using the state management.

### Credits

This pull request is part of the "Citizen Science Logger" project and, provided by the [ETH Library Lab](https://www.librarylab.ethz.ch/).